### PR TITLE
feat: add `handleRPCRequest()`

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const FORM_DATA_BOUNDARY_PREFIX = "r19-rpc-";

--- a/src/handleRPCRequest.ts
+++ b/src/handleRPCRequest.ts
@@ -1,0 +1,277 @@
+import { Readable } from "node:stream";
+import { Buffer } from "node:buffer";
+import busboy from "busboy";
+
+import { deserialize } from "./lib/deserialize";
+import { encodeFormData } from "./lib/encodeFormData";
+import { isErrorLike } from "./lib/isErrorLike";
+import { objectToFormData } from "./lib/objectToFormData.server";
+import { unflattenObject } from "./lib/unflattenObject";
+import { formDataToObject } from "./lib/formDataToObject.client";
+
+import { FORM_DATA_BOUNDARY_PREFIX } from "./constants";
+import { Procedure, Procedures, ProcedureCallServerArgs } from "./types";
+
+const findProcedure = (
+	procedures: Procedures,
+	path: string[],
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Procedure<any> | undefined => {
+	// Use a clone to prevent unwanted mutations.
+	path = [...path];
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	let proceduresPointer: Procedures | Procedure<any> = procedures;
+
+	while (path.length > 0) {
+		const pathSegment = path.shift();
+
+		if (pathSegment) {
+			proceduresPointer = proceduresPointer[pathSegment];
+
+			if (typeof proceduresPointer === "function") {
+				return proceduresPointer;
+			} else if (proceduresPointer === undefined) {
+				return;
+			}
+		}
+	}
+};
+
+type ParseRPCClientArgs = {
+	contentTypeHeader: string;
+	body: string;
+};
+
+const readRPCClientArgs = async (args: ParseRPCClientArgs) => {
+	const bb = busboy({
+		headers: {
+			"content-type": args.contentTypeHeader,
+		},
+	});
+
+	const clientArgs = {} as Record<string, unknown>;
+
+	const promise = new Promise<ProcedureCallServerArgs>((resolve, reject) => {
+		bb.on("file", (name, file, _info) => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const chunks: any[] = [];
+
+			file.on("data", (data) => {
+				chunks.push(data);
+			});
+
+			file.on("close", () => {
+				clientArgs[name as keyof typeof clientArgs] = Buffer.concat(chunks);
+			});
+		});
+
+		bb.on("field", (name, value, _info) => {
+			clientArgs[name as keyof typeof clientArgs] = deserialize(value);
+		});
+
+		bb.on("close", () => {
+			const unflattenedArgs = unflattenObject(
+				clientArgs,
+			) as ProcedureCallServerArgs;
+
+			resolve(unflattenedArgs);
+		});
+
+		bb.on("error", (error) => {
+			reject(error);
+		});
+	});
+
+	Readable.from(args.body).pipe(bb);
+
+	return promise;
+};
+
+const isPlainObject = <Value>(
+	value: unknown,
+): value is Record<PropertyKey, Value> => {
+	if (typeof value !== "object" || value === null) {
+		return false;
+	}
+
+	const prototype = Object.getPrototypeOf(value);
+
+	return (
+		(prototype === null ||
+			prototype === Object.prototype ||
+			Object.getPrototypeOf(prototype) === null) &&
+		!(Symbol.toStringTag in value) &&
+		!(Symbol.iterator in value)
+	);
+};
+
+const prepareRes = (res: unknown) => {
+	if (Array.isArray(res)) {
+		const preparedRes: unknown[] = [];
+
+		for (let i = 0; i < res.length; i++) {
+			preparedRes[i] = prepareRes(res[i]);
+		}
+
+		return preparedRes;
+	}
+
+	if (isPlainObject(res)) {
+		const preparedRes: Record<PropertyKey, unknown> = {};
+
+		for (const key in res) {
+			preparedRes[key] = prepareRes(res[key as keyof typeof res]);
+		}
+
+		return preparedRes;
+	}
+
+	if (res instanceof Error || isErrorLike(res)) {
+		return {
+			name: res.name,
+			message: res.message,
+			stack: process.env.NODE_ENV === "development" ? res.stack : undefined,
+		};
+	}
+
+	return res;
+};
+
+type HandleRPCRequestArgs<TProcedures extends Procedures> = {
+	procedures: TProcedures;
+} & (
+	| {
+			contentTypeHeader: string | null | undefined;
+			body: string | undefined;
+	  }
+	| {
+			formData: FormData;
+	  }
+);
+
+type HandleRPCRequestReturnType = {
+	stream: Readable;
+	headers: Record<string, string>;
+	statusCode?: number;
+};
+
+export const handleRPCRequest = async <TProcedures extends Procedures>(
+	args: HandleRPCRequestArgs<TProcedures>,
+): Promise<HandleRPCRequestReturnType> => {
+	let clientArgs: ProcedureCallServerArgs;
+
+	if ("body" in args) {
+		if (!args.body) {
+			throw new Error(
+				"Invalid request body. Only requests from an r19 client are accepted.",
+			);
+		}
+
+		if (!args.contentTypeHeader) {
+			throw new Error(
+				"Invalid Content-Type header. Only requests from an r19 client are accepted.",
+			);
+		}
+
+		clientArgs = await readRPCClientArgs({
+			contentTypeHeader: args.contentTypeHeader,
+			body: args.body,
+		});
+	} else {
+		clientArgs = formDataToObject(args.formData) as ProcedureCallServerArgs;
+	}
+
+	const procedure = findProcedure(args.procedures, clientArgs.procedurePath);
+
+	if (!procedure) {
+		const formData = objectToFormData({
+			error: {
+				name: "RPCError",
+				message: `Invalid procedure name: ${clientArgs.procedurePath.join(
+					".",
+				)}`,
+			},
+		});
+
+		const { headers, stream } = encodeFormData(formData, {
+			boundaryPrefix: FORM_DATA_BOUNDARY_PREFIX,
+		});
+
+		return {
+			stream,
+			headers,
+			statusCode: 500,
+		};
+	}
+
+	let res: unknown;
+
+	try {
+		res = await procedure(clientArgs.procedureArgs);
+
+		res = prepareRes(res);
+	} catch (error) {
+		if (isErrorLike(error)) {
+			const formData = objectToFormData({
+				error: {
+					name: error.name,
+					message: error.message,
+					stack:
+						process.env.NODE_ENV === "development" ? error.stack : undefined,
+				},
+			});
+
+			const { headers, stream } = encodeFormData(formData, {
+				boundaryPrefix: FORM_DATA_BOUNDARY_PREFIX,
+			});
+
+			return {
+				stream,
+				headers,
+				statusCode: 500,
+			};
+		}
+
+		throw error;
+	}
+
+	try {
+		const formData = objectToFormData({
+			data: res,
+		});
+
+		const { headers, stream } = encodeFormData(formData, {
+			boundaryPrefix: FORM_DATA_BOUNDARY_PREFIX,
+		});
+
+		return {
+			stream,
+			headers,
+		};
+	} catch (error) {
+		if (error instanceof Error) {
+			console.error(error);
+
+			const formData = objectToFormData({
+				error: {
+					name: "RPCError",
+					message:
+						"Unable to serialize server response. Check the server log for details.",
+				},
+			});
+
+			const { headers, stream } = encodeFormData(formData, {
+				boundaryPrefix: FORM_DATA_BOUNDARY_PREFIX,
+			});
+
+			return {
+				stream,
+				headers,
+				statusCode: 500,
+			};
+		}
+
+		throw error;
+	}
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,4 +10,6 @@ export {
 	OmittableProcedures,
 } from "./proceduresFromInstance";
 
+export { handleRPCRequest } from "./handleRPCRequest";
+
 export { Procedure, Procedures, ExtractProcedures } from "./types";

--- a/src/lib/encodeFormData.ts
+++ b/src/lib/encodeFormData.ts
@@ -1,0 +1,131 @@
+/**
+ * The following code is a modified version of the following sources:
+ *
+ * 1. `formDataToBlob()` from `jimmywarting/FormData` on GitHub
+ *
+ *    Source:
+ *    https://github.com/jimmywarting/FormData/blob/820421ba9ee291cbf6b1b21aaa14ae1846d7c66c/formdata-to-blob.js
+ *
+ *    MIT License
+ *
+ *    Copyright (c) 2016 Jimmy Karl Roland Wärting
+ *
+ *    Permission is hereby granted, free of charge, to any person obtaining a copy
+ *    of this software and associated documentation files (the "Software"), to
+ *    deal in the Software without restriction, including without limitation the
+ *    rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *    and/or sell copies of the Software, and to permit persons to whom the
+ *    Software is furnished to do so, subject to the following conditions:
+ *
+ *    The above copyright notice and this permission notice shall be included in
+ *    all copies or substantial portions of the Software.
+ *
+ *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *    DEALINGS IN THE SOFTWARE.
+ * 2. `readStream()` from `octet-stream/form-data-encoder` on GitHub.
+ *
+ *    Source:
+ *    https://github.com/octet-stream/form-data-encoder/blob/f884063dc10fccd718af8864fbd62ee860ccf9f5/src/util/getStreamIterator.ts
+ *
+ *    The MIT License (MIT)
+ *
+ *    Copyright (c) 2021-present Nick K.
+ *
+ *    Permission is hereby granted, free of charge, to any person obtaining a copy
+ *    of this software and associated documentation files (the "Software"), to
+ *    deal in the Software without restriction, including without limitation the
+ *    rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *    and/or sell copies of the Software, and to permit persons to whom the
+ *    Software is furnished to do so, subject to the following conditions:
+ *
+ *    The above copyright notice and this permission notice shall be included in
+ *    all copies or substantial portions of the Software.
+ *
+ *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *    DEALINGS IN THE SOFTWARE.
+ */
+
+import { Readable } from "node:stream";
+import { FormData } from "formdata-node";
+
+/**
+ * Reads from a given ReadableStream.
+ *
+ * @param readable - A ReadableStream from which to read.
+ */
+async function* readStream(
+	readable: ReadableStream<Uint8Array>,
+): AsyncGenerator<Uint8Array, void, undefined> {
+	const reader = readable.getReader();
+
+	while (true) {
+		const { done, value } = await reader.read();
+
+		if (done) {
+			break;
+		}
+
+		yield value;
+	}
+}
+
+const escape = (str: string, isFilename?: boolean) =>
+	(isFilename ? str : str.replace(/\r?\n|\r/g, "\r\n"))
+		.replace(/\n/g, "%0A")
+		.replace(/\r/g, "%0D")
+		.replace(/"/g, "%22");
+
+type EncodeFormDataConfig = {
+	boundaryPrefix?: string;
+};
+
+type EncodeFormDataReturnType = {
+	headers: Record<string, string>;
+	stream: Readable;
+};
+
+export const encodeFormData = (
+	formData: FormData,
+	config: EncodeFormDataConfig = {},
+): EncodeFormDataReturnType => {
+	const boundary = (config.boundaryPrefix || "") + Math.random();
+	const prefix = `--${boundary}\r\nContent-Disposition: form-data;`;
+
+	async function* chunks() {
+		for (const [name, value] of formData) {
+			if (typeof value === "string") {
+				yield `${prefix} name="${escape(name)}"` +
+					"\r\n\r\n" +
+					value.replace(/\r(?!\n)|(?<!\r)\n/g, "\r\n") +
+					"\r\n";
+			} else {
+				yield `${prefix} name="${escape(name)}"; ` +
+					`filename="${escape(value.name, true)}"` +
+					"\r\n" +
+					`Content-Type: ${value.type || "application/octet-stream"}` +
+					"\r\n\r\n";
+				yield* readStream(value.stream());
+				yield "\r\n";
+			}
+		}
+
+		yield `--${boundary}--\r\n\r\n`;
+	}
+
+	return {
+		headers: {
+			"Content-Type": `multipart/form-data; boundary=${boundary}`,
+		},
+		stream: Readable.from(chunks()),
+	};
+};

--- a/src/lib/readRPCClientArgs.ts
+++ b/src/lib/readRPCClientArgs.ts
@@ -1,49 +1,55 @@
 import { Buffer } from "node:buffer";
-import { H3Event, getHeaders } from "h3";
+import { H3Event, getHeaders, readRawBody } from "h3";
 import busboy from "busboy";
+import { Readable } from "node:stream";
 
 import { ProcedureCallServerArgs } from "../types";
 
 import { deserialize } from "./deserialize";
 import { unflattenObject } from "./unflattenObject";
 
-export const readRPCClientArgs = (
+export const readRPCClientArgs = async (
 	event: H3Event,
-): Promise<ProcedureCallServerArgs> => {
-	return new Promise((resolve, reject) => {
+): Promise<ProcedureCallServerArgs | undefined> => {
+	const body = await readRawBody(event, false);
+
+	if (body) {
+		const bodyStream = Readable.from(body);
 		const headers = getHeaders(event);
-
 		const bb = busboy({ headers });
-
 		const args = {} as Record<string, unknown>;
 
-		bb.on("file", (name, file, _info) => {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const chunks: any[] = [];
+		return new Promise<ProcedureCallServerArgs>((resolve, reject) => {
+			bb.on("file", (name, file, _info) => {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				const chunks: any[] = [];
 
-			file.on("data", (data) => {
-				chunks.push(data);
+				file.on("data", (data) => {
+					chunks.push(data);
+				});
+
+				file.on("close", () => {
+					args[name as keyof typeof args] = Buffer.concat(chunks);
+				});
 			});
 
-			file.on("close", () => {
-				args[name as keyof typeof args] = Buffer.concat(chunks);
+			bb.on("field", (name, value, _info) => {
+				args[name as keyof typeof args] = deserialize(value);
 			});
+
+			bb.on("close", () => {
+				const unflattenedArgs = unflattenObject(
+					args,
+				) as ProcedureCallServerArgs;
+
+				resolve(unflattenedArgs);
+			});
+
+			bb.on("error", (error) => {
+				reject(error);
+			});
+
+			bodyStream.pipe(bb);
 		});
-
-		bb.on("field", (name, value, _info) => {
-			args[name as keyof typeof args] = deserialize(value);
-		});
-
-		bb.on("close", () => {
-			const unflattenedArgs = unflattenObject(args) as ProcedureCallServerArgs;
-
-			resolve(unflattenedArgs);
-		});
-
-		bb.on("error", (error) => {
-			reject(error);
-		});
-
-		event.req.pipe(bb);
-	});
+	}
 };

--- a/src/lib/sendFormData.ts
+++ b/src/lib/sendFormData.ts
@@ -1,142 +1,16 @@
-/**
- * The following code is a modified version of the following sources:
- *
- * 1. `formDataToBlob()` from `jimmywarting/FormData` on GitHub
- *
- *    Source:
- *    https://github.com/jimmywarting/FormData/blob/820421ba9ee291cbf6b1b21aaa14ae1846d7c66c/formdata-to-blob.js
- *
- *    MIT License
- *
- *    Copyright (c) 2016 Jimmy Karl Roland Wärting
- *
- *    Permission is hereby granted, free of charge, to any person obtaining a copy
- *    of this software and associated documentation files (the "Software"), to
- *    deal in the Software without restriction, including without limitation the
- *    rights to use, copy, modify, merge, publish, distribute, sublicense,
- *    and/or sell copies of the Software, and to permit persons to whom the
- *    Software is furnished to do so, subject to the following conditions:
- *
- *    The above copyright notice and this permission notice shall be included in
- *    all copies or substantial portions of the Software.
- *
- *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
- *    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- *    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- *    DEALINGS IN THE SOFTWARE.
- * 2. `readStream()` from `octet-stream/form-data-encoder` on GitHub.
- *
- *    Source:
- *    https://github.com/octet-stream/form-data-encoder/blob/f884063dc10fccd718af8864fbd62ee860ccf9f5/src/util/getStreamIterator.ts
- *
- *    The MIT License (MIT)
- *
- *    Copyright (c) 2021-present Nick K.
- *
- *    Permission is hereby granted, free of charge, to any person obtaining a copy
- *    of this software and associated documentation files (the "Software"), to
- *    deal in the Software without restriction, including without limitation the
- *    rights to use, copy, modify, merge, publish, distribute, sublicense,
- *    and/or sell copies of the Software, and to permit persons to whom the
- *    Software is furnished to do so, subject to the following conditions:
- *
- *    The above copyright notice and this permission notice shall be included in
- *    all copies or substantial portions of the Software.
- *
- *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
- *    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- *    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- *    DEALINGS IN THE SOFTWARE.
- */
-
-import { Readable } from "node:stream";
 import { H3Event, sendStream, setHeaders } from "h3";
 import { FormData } from "formdata-node";
 
-/**
- * Reads from a given ReadableStream.
- *
- * @param readable - A ReadableStream from which to read.
- */
-async function* readStream(
-	readable: ReadableStream<Uint8Array>,
-): AsyncGenerator<Uint8Array, void, undefined> {
-	const reader = readable.getReader();
+import { FORM_DATA_BOUNDARY_PREFIX } from "../constants";
 
-	while (true) {
-		const { done, value } = await reader.read();
-
-		if (done) {
-			break;
-		}
-
-		yield value;
-	}
-}
-
-const escape = (str: string, isFilename?: boolean) =>
-	(isFilename ? str : str.replace(/\r?\n|\r/g, "\r\n"))
-		.replace(/\n/g, "%0A")
-		.replace(/\r/g, "%0D")
-		.replace(/"/g, "%22");
-
-type EncodeFormDataConfig = {
-	boundaryPrefix?: string;
-};
-
-type EncodeFormDataReturnType = {
-	headers: Record<string, string>;
-	stream: Readable;
-};
-
-const encodeFormData = (
-	formData: FormData,
-	config: EncodeFormDataConfig = {},
-): EncodeFormDataReturnType => {
-	const boundary = (config.boundaryPrefix || "") + Math.random();
-	const prefix = `--${boundary}\r\nContent-Disposition: form-data;`;
-
-	async function* chunks() {
-		for (const [name, value] of formData) {
-			if (typeof value === "string") {
-				yield `${prefix} name="${escape(name)}"` +
-					"\r\n\r\n" +
-					value.replace(/\r(?!\n)|(?<!\r)\n/g, "\r\n") +
-					"\r\n";
-			} else {
-				yield `${prefix} name="${escape(name)}"; ` +
-					`filename="${escape(value.name, true)}"` +
-					"\r\n" +
-					`Content-Type: ${value.type || "application/octet-stream"}` +
-					"\r\n\r\n";
-				yield* readStream(value.stream());
-				yield "\r\n";
-			}
-		}
-
-		yield `--${boundary}--\r\n\r\n`;
-	}
-
-	return {
-		headers: {
-			"Content-Type": `multipart/form-data; boundary=${boundary}`,
-		},
-		stream: Readable.from(chunks()),
-	};
-};
+import { encodeFormData } from "./encodeFormData";
 
 export const sendFormData = (
 	event: H3Event,
 	formData: FormData,
 ): Promise<void> => {
 	const { headers, stream } = encodeFormData(formData, {
-		boundaryPrefix: "rpc-",
+		boundaryPrefix: FORM_DATA_BOUNDARY_PREFIX,
 	});
 
 	setHeaders(event, headers);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds a new export called `handleRPCRequest()`. It lets you process an RPC request without a running server by providing your set of procedures and your request in the form of a FormData object or a body string and its `Content-Type` header. `createRPCMiddleware()` uses `handleRPCRequest()` internally.

The new function is most useful in tests where you do not want to run an actual server for each test.

It has the following signature:

```typescript
import type { Procedures } from "r19";

type HandleRPCRequestArgs<TProcedures extends Procedures> = {
  procedures: TProcedures;
} & (
  | {
      contentTypeHeader: string | null | undefined;
      body: string | undefined;
    }
  | {
      formData: FormData;
    }
);

type HandleRPCRequestReturnType = {
  stream: Readable;
  headers: Record<string, string>;
  statusCode?: number;
};

const handleRPCRequest: <TProcedures extends Procedures>(
  args: HandleRPCRequestArgs<TProcedures>
) => Promise<HandleRPCRequestReturnType>;
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
