### PR TITLE
fix: properly close middleware using `next()`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@msgpack/msgpack": "^2.8.0"
 			},
 			"devDependencies": {
+				"@fastify/middie": "^8.1.0",
 				"@size-limit/preset-small-lib": "^8.1.1",
 				"@types/express": "^4.17.15",
 				"@typescript-eslint/eslint-plugin": "^5.48.2",
@@ -22,6 +23,8 @@
 				"eslint-plugin-prettier": "^4.2.1",
 				"eslint-plugin-tsdoc": "^0.2.17",
 				"express": "^4.18.2",
+				"fastify": "^4.11.0",
+				"h3": "^1.0.2",
 				"msw": "^0.49.2",
 				"node-fetch": "^3.3.0",
 				"prettier": "^2.8.3",
@@ -523,6 +526,77 @@
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
+		},
+		"node_modules/@fastify/ajv-compiler": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.5.0.tgz",
+			"integrity": "sha512-ebbEtlI7dxXF5ziNdr05mOY8NnDiPB1XvAlLHctRt/Rc+C3LCOVW5imUVX+mhvUhnNzmPBHewUkOFgGlCxgdAA==",
+			"dev": true,
+			"dependencies": {
+				"ajv": "^8.11.0",
+				"ajv-formats": "^2.1.1",
+				"fast-uri": "^2.0.0"
+			}
+		},
+		"node_modules/@fastify/ajv-compiler/node_modules/ajv": {
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@fastify/ajv-compiler/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true
+		},
+		"node_modules/@fastify/deepmerge": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-1.3.0.tgz",
+			"integrity": "sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A==",
+			"dev": true
+		},
+		"node_modules/@fastify/error": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.2.0.tgz",
+			"integrity": "sha512-KAfcLa+CnknwVi5fWogrLXgidLic+GXnLjijXdpl8pvkvbXU5BGa37iZO9FGvsh9ZL4y+oFi5cbHBm5UOG+dmQ==",
+			"dev": true
+		},
+		"node_modules/@fastify/fast-json-stringify-compiler": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.2.0.tgz",
+			"integrity": "sha512-ypZynRvXA3dibfPykQN3RB5wBdEUgSGgny8Qc6k163wYPLD4mEGEDkACp+00YmqkGvIm8D/xYoHajwyEdWD/eg==",
+			"dev": true,
+			"dependencies": {
+				"fast-json-stringify": "^5.0.0"
+			}
+		},
+		"node_modules/@fastify/middie": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@fastify/middie/-/middie-8.1.0.tgz",
+			"integrity": "sha512-VvUCLfKx2j6KSnh8puT8QW7d5YNzi2fD/4HcFvRQ3a7sHlCo+qtfX2fqzFvNqnMVbNft7GX1JL5if/riUiXsyg==",
+			"dev": true,
+			"dependencies": {
+				"fastify-plugin": "^4.0.0",
+				"path-to-regexp": "^6.1.0",
+				"reusify": "^1.0.4"
+			}
+		},
+		"node_modules/@fastify/middie/node_modules/path-to-regexp": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+			"integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+			"dev": true
 		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.11.8",
@@ -1202,6 +1276,24 @@
 			"dev": true,
 			"optional": true
 		},
+		"node_modules/abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"dev": true,
+			"dependencies": {
+				"event-target-shim": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=6.5"
+			}
+		},
+		"node_modules/abstract-logging": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+			"integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+			"dev": true
+		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1267,6 +1359,45 @@
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
+		"node_modules/ajv-formats": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+			"dev": true,
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ajv-formats/node_modules/ajv": {
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true
+		},
 		"node_modules/ansi-escapes": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -1331,6 +1462,12 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/archy": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+			"integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
+			"dev": true
+		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1376,6 +1513,15 @@
 				"node": "*"
 			}
 		},
+		"node_modules/atomic-sleep": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+			"integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
 		"node_modules/available-typed-arrays": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -1386,6 +1532,17 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/avvio": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/avvio/-/avvio-8.2.0.tgz",
+			"integrity": "sha512-bbCQdg7bpEv6kGH41RO/3B2/GMMmJSo2iBK+X8AWN9mujtfUipMDfIjsgHCfpnKqoGEQrrmCDKSa5OQ19+fDmg==",
+			"dev": true,
+			"dependencies": {
+				"archy": "^1.0.0",
+				"debug": "^4.0.0",
+				"fastq": "^1.6.1"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -2144,6 +2301,12 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/cookie-es": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-0.5.0.tgz",
+			"integrity": "sha512-RyZrFi6PNpBFbIaQjXDlFIhFVqV42QeKSZX1yQIl6ihImq6vcHNGMtqQ/QzY3RMPuYSkvsRwtnt5M9NeYxKt0g==",
+			"dev": true
+		},
 		"node_modules/cookie-signature": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -2314,6 +2477,12 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/destr": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/destr/-/destr-1.2.2.tgz",
+			"integrity": "sha512-lrbCJwD9saUQrqUfXvl6qoM+QN3W7tLV5pAOs+OqOmopCCz/JkE05MHedJR1xfk4IAnZuJXPVuN5+7jNA2ZCiA==",
+			"dev": true
 		},
 		"node_modules/destroy": {
 			"version": "1.2.0",
@@ -2818,6 +2987,15 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/events": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -2898,6 +3076,12 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/fast-decode-uri-component": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+			"integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+			"dev": true
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2944,10 +3128,99 @@
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true
 		},
+		"node_modules/fast-json-stringify": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.5.0.tgz",
+			"integrity": "sha512-rmw2Z8/mLkND8zI+3KTYIkNPEoF5v6GqDP/o+g7H3vjdWjBwuKpgAYFHIzL6ORRB+iqDjjtJnLIW9Mzxn5szOA==",
+			"dev": true,
+			"dependencies": {
+				"@fastify/deepmerge": "^1.0.0",
+				"ajv": "^8.10.0",
+				"ajv-formats": "^2.1.1",
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^2.1.0",
+				"rfdc": "^1.2.0"
+			}
+		},
+		"node_modules/fast-json-stringify/node_modules/ajv": {
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true
+		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+			"dev": true
+		},
+		"node_modules/fast-querystring": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.0.tgz",
+			"integrity": "sha512-LWkjBCZlxjnSanuPpZ6mHswjy8hQv3VcPJsQB3ltUF2zjvrycr0leP3TSTEEfvQ1WEMSRl5YNsGqaft9bjLqEw==",
+			"dev": true,
+			"dependencies": {
+				"fast-decode-uri-component": "^1.0.1"
+			}
+		},
+		"node_modules/fast-redact": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
+			"integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/fast-uri": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.2.0.tgz",
+			"integrity": "sha512-cIusKBIt/R/oI6z/1nyfe2FvGKVTohVRfvkOhvx0nCEW+xf5NoCXjAHcWp93uOUBchzYcsvPlrapAdX1uW+YGg==",
+			"dev": true
+		},
+		"node_modules/fastify": {
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/fastify/-/fastify-4.11.0.tgz",
+			"integrity": "sha512-JteZ8pjEqd+6n+azQnQfSJV8MUMxAmxbvC2Dx/Mybj039Lf/u3kda9Kq84uy/huCpqCzZoyHIZS5JFGF3wLztw==",
+			"dev": true,
+			"dependencies": {
+				"@fastify/ajv-compiler": "^3.3.1",
+				"@fastify/error": "^3.0.0",
+				"@fastify/fast-json-stringify-compiler": "^4.1.0",
+				"abstract-logging": "^2.0.1",
+				"avvio": "^8.2.0",
+				"content-type": "^1.0.4",
+				"find-my-way": "^7.3.0",
+				"light-my-request": "^5.6.1",
+				"pino": "^8.5.0",
+				"process-warning": "^2.0.0",
+				"proxy-addr": "^2.0.7",
+				"rfdc": "^1.3.0",
+				"secure-json-parse": "^2.5.0",
+				"semver": "^7.3.7",
+				"tiny-lru": "^10.0.0"
+			}
+		},
+		"node_modules/fastify-plugin": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.5.0.tgz",
+			"integrity": "sha512-79ak0JxddO0utAXAQ5ccKhvs6vX2MGyHHMMsmZkBANrq3hXc1CHzvNPHOcvTsVMEPl5I+NT+RO4YKMGehOfSIg==",
 			"dev": true
 		},
 		"node_modules/fastq": {
@@ -3062,6 +3335,20 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true
+		},
+		"node_modules/find-my-way": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-7.4.0.tgz",
+			"integrity": "sha512-JFT7eURLU5FumlZ3VBGnveId82cZz7UR7OUu+THQJOwdQXxmS/g8v0KLoFhv97HreycOrmAbqjXD/4VG2j0uMQ==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-querystring": "^1.0.0",
+				"safe-regex2": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
 		},
 		"node_modules/find-up": {
 			"version": "5.0.0",
@@ -3444,6 +3731,18 @@
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+			}
+		},
+		"node_modules/h3": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/h3/-/h3-1.0.2.tgz",
+			"integrity": "sha512-25QqjQMz8pX1NI2rZ/ziNT9B8Aog7jmu2a0o8Qm9kKoH3zOhE+2icVs069h6DEp0g1Dst1+zKfRdRYcK0MogJA==",
+			"dev": true,
+			"dependencies": {
+				"cookie-es": "^0.5.0",
+				"destr": "^1.2.2",
+				"radix3": "^1.0.0",
+				"ufo": "^1.0.1"
 			}
 		},
 		"node_modules/handlebars": {
@@ -4086,6 +4385,17 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/light-my-request": {
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.8.0.tgz",
+			"integrity": "sha512-4BtD5C+VmyTpzlDPCZbsatZMJVgUIciSOwYhJDCbLffPZ35KoDkDj4zubLeHDEb35b4kkPeEv5imbh+RJxK/Pg==",
+			"dev": true,
+			"dependencies": {
+				"cookie": "^0.5.0",
+				"process-warning": "^2.0.0",
+				"set-cookie-parser": "^2.4.1"
 			}
 		},
 		"node_modules/lilconfig": {
@@ -5366,6 +5676,12 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/on-exit-leak-free": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+			"integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w==",
+			"dev": true
+		},
 		"node_modules/on-finished": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -5620,6 +5936,92 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/pino": {
+			"version": "8.8.0",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-8.8.0.tgz",
+			"integrity": "sha512-cF8iGYeu2ODg2gIwgAHcPrtR63ILJz3f7gkogaHC/TXVVXxZgInmNYiIpDYEwgEkxZti2Se6P2W2DxlBIZe6eQ==",
+			"dev": true,
+			"dependencies": {
+				"atomic-sleep": "^1.0.0",
+				"fast-redact": "^3.1.1",
+				"on-exit-leak-free": "^2.1.0",
+				"pino-abstract-transport": "v1.0.0",
+				"pino-std-serializers": "^6.0.0",
+				"process-warning": "^2.0.0",
+				"quick-format-unescaped": "^4.0.3",
+				"real-require": "^0.2.0",
+				"safe-stable-stringify": "^2.3.1",
+				"sonic-boom": "^3.1.0",
+				"thread-stream": "^2.0.0"
+			},
+			"bin": {
+				"pino": "bin.js"
+			}
+		},
+		"node_modules/pino-abstract-transport": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+			"integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+			"dev": true,
+			"dependencies": {
+				"readable-stream": "^4.0.0",
+				"split2": "^4.0.0"
+			}
+		},
+		"node_modules/pino-abstract-transport/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/pino-abstract-transport/node_modules/readable-stream": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.3.0.tgz",
+			"integrity": "sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==",
+			"dev": true,
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/pino-abstract-transport/node_modules/split2": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+			"integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10.x"
+			}
+		},
+		"node_modules/pino-std-serializers": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.1.0.tgz",
+			"integrity": "sha512-KO0m2f1HkrPe9S0ldjx7za9BJjeHqBku5Ch8JyxETxT8dEFGz1PwgrHaOQupVYitpzbFSYm7nnljxD8dik2c+g==",
+			"dev": true
+		},
 		"node_modules/pkg-types": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.1.tgz",
@@ -5714,10 +6116,25 @@
 				"prettier": ">=2.1.2"
 			}
 		},
+		"node_modules/process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		},
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
+		},
+		"node_modules/process-warning": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.1.0.tgz",
+			"integrity": "sha512-9C20RLxrZU/rFnxWncDkuF6O999NdIf3E1ws4B0ZeY3sRVPzWBMsYDE2lxjxhiXxg464cQTgKUGm8/i6y2YGXg==",
 			"dev": true
 		},
 		"node_modules/proxy-addr": {
@@ -5787,6 +6204,12 @@
 				}
 			]
 		},
+		"node_modules/quick-format-unescaped": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+			"integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+			"dev": true
+		},
 		"node_modules/quick-lru": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -5795,6 +6218,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/radix3": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/radix3/-/radix3-1.0.0.tgz",
+			"integrity": "sha512-6n3AEXth91ASapMVKiEh2wrbFJmI+NBilrWE0AbiGgfm0xet0QXC8+a3K19r1UVYjUjctUgB053c3V/J6V0kCQ==",
+			"dev": true
 		},
 		"node_modules/range-parser": {
 			"version": "1.2.1",
@@ -5988,6 +6417,15 @@
 				"node": ">=8.10.0"
 			}
 		},
+		"node_modules/real-require": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+			"integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 12.13.0"
+			}
+		},
 		"node_modules/redent": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -6017,6 +6455,15 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -6057,6 +6504,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/ret": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+			"integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -6066,6 +6522,12 @@
 				"iojs": ">=1.0.0",
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/rfdc": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+			"integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+			"dev": true
 		},
 		"node_modules/rimraf": {
 			"version": "3.0.2",
@@ -6171,10 +6633,34 @@
 				}
 			]
 		},
+		"node_modules/safe-regex2": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-2.0.0.tgz",
+			"integrity": "sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==",
+			"dev": true,
+			"dependencies": {
+				"ret": "~0.2.0"
+			}
+		},
+		"node_modules/safe-stable-stringify": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.2.tgz",
+			"integrity": "sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
+		},
+		"node_modules/secure-json-parse": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+			"integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
 			"dev": true
 		},
 		"node_modules/semver": {
@@ -6340,6 +6826,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/sonic-boom": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.2.1.tgz",
+			"integrity": "sha512-iITeTHxy3B9FGu8aVdiDXUVAcHMF9Ss0cCsAOo2HfCrmVGT3/DT5oYaeu0M/YKZDlKTvChEyPq0zI9Hf33EX6A==",
+			"dev": true,
+			"dependencies": {
+				"atomic-sleep": "^1.0.0"
 			}
 		},
 		"node_modules/source-map": {
@@ -6686,6 +7181,15 @@
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
 		},
+		"node_modules/thread-stream": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.3.0.tgz",
+			"integrity": "sha512-kaDqm1DET9pp3NXwR8382WHbnpXnRkN9xGN9dQt3B2+dmXiW8X1SOwmFOxAErEQ47ObhZ96J6yhZNXuyCOL7KA==",
+			"dev": true,
+			"dependencies": {
+				"real-require": "^0.2.0"
+			}
+		},
 		"node_modules/through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -6699,6 +7203,15 @@
 			"dev": true,
 			"dependencies": {
 				"readable-stream": "3"
+			}
+		},
+		"node_modules/tiny-lru": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-10.0.1.tgz",
+			"integrity": "sha512-Vst+6kEsWvb17Zpz14sRJV/f8bUWKhqm6Dc+v08iShmIJ/WxqWytHzCTd6m88pS33rE2zpX34TRmOpAJPloNCA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/tinybench": {
@@ -7631,6 +8144,77 @@
 				"strip-json-comments": "^3.1.1"
 			}
 		},
+		"@fastify/ajv-compiler": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.5.0.tgz",
+			"integrity": "sha512-ebbEtlI7dxXF5ziNdr05mOY8NnDiPB1XvAlLHctRt/Rc+C3LCOVW5imUVX+mhvUhnNzmPBHewUkOFgGlCxgdAA==",
+			"dev": true,
+			"requires": {
+				"ajv": "^8.11.0",
+				"ajv-formats": "^2.1.1",
+				"fast-uri": "^2.0.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "8.12.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+					"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"json-schema-traverse": "^1.0.0",
+						"require-from-string": "^2.0.2",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"json-schema-traverse": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+					"dev": true
+				}
+			}
+		},
+		"@fastify/deepmerge": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-1.3.0.tgz",
+			"integrity": "sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A==",
+			"dev": true
+		},
+		"@fastify/error": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.2.0.tgz",
+			"integrity": "sha512-KAfcLa+CnknwVi5fWogrLXgidLic+GXnLjijXdpl8pvkvbXU5BGa37iZO9FGvsh9ZL4y+oFi5cbHBm5UOG+dmQ==",
+			"dev": true
+		},
+		"@fastify/fast-json-stringify-compiler": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.2.0.tgz",
+			"integrity": "sha512-ypZynRvXA3dibfPykQN3RB5wBdEUgSGgny8Qc6k163wYPLD4mEGEDkACp+00YmqkGvIm8D/xYoHajwyEdWD/eg==",
+			"dev": true,
+			"requires": {
+				"fast-json-stringify": "^5.0.0"
+			}
+		},
+		"@fastify/middie": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@fastify/middie/-/middie-8.1.0.tgz",
+			"integrity": "sha512-VvUCLfKx2j6KSnh8puT8QW7d5YNzi2fD/4HcFvRQ3a7sHlCo+qtfX2fqzFvNqnMVbNft7GX1JL5if/riUiXsyg==",
+			"dev": true,
+			"requires": {
+				"fastify-plugin": "^4.0.0",
+				"path-to-regexp": "^6.1.0",
+				"reusify": "^1.0.4"
+			},
+			"dependencies": {
+				"path-to-regexp": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+					"integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+					"dev": true
+				}
+			}
+		},
 		"@humanwhocodes/config-array": {
 			"version": "0.11.8",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -8131,6 +8715,21 @@
 			"dev": true,
 			"optional": true
 		},
+		"abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"dev": true,
+			"requires": {
+				"event-target-shim": "^5.0.0"
+			}
+		},
+		"abstract-logging": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+			"integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+			"dev": true
+		},
 		"accepts": {
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -8178,6 +8777,35 @@
 				"uri-js": "^4.2.2"
 			}
 		},
+		"ajv-formats": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+			"dev": true,
+			"requires": {
+				"ajv": "^8.0.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "8.12.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+					"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"json-schema-traverse": "^1.0.0",
+						"require-from-string": "^2.0.2",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"json-schema-traverse": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+					"dev": true
+				}
+			}
+		},
 		"ansi-escapes": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -8220,6 +8848,12 @@
 				"picomatch": "^2.0.4"
 			}
 		},
+		"archy": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+			"integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
+			"dev": true
+		},
 		"argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -8256,11 +8890,28 @@
 			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
 			"dev": true
 		},
+		"atomic-sleep": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+			"integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+			"dev": true
+		},
 		"available-typed-arrays": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
 			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
 			"dev": true
+		},
+		"avvio": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/avvio/-/avvio-8.2.0.tgz",
+			"integrity": "sha512-bbCQdg7bpEv6kGH41RO/3B2/GMMmJSo2iBK+X8AWN9mujtfUipMDfIjsgHCfpnKqoGEQrrmCDKSa5OQ19+fDmg==",
+			"dev": true,
+			"requires": {
+				"archy": "^1.0.0",
+				"debug": "^4.0.0",
+				"fastq": "^1.6.1"
+			}
 		},
 		"balanced-match": {
 			"version": "1.0.2",
@@ -8833,6 +9484,12 @@
 			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
 			"dev": true
 		},
+		"cookie-es": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-0.5.0.tgz",
+			"integrity": "sha512-RyZrFi6PNpBFbIaQjXDlFIhFVqV42QeKSZX1yQIl6ihImq6vcHNGMtqQ/QzY3RMPuYSkvsRwtnt5M9NeYxKt0g==",
+			"dev": true
+		},
 		"cookie-signature": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -8956,6 +9613,12 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
 			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"dev": true
+		},
+		"destr": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/destr/-/destr-1.2.2.tgz",
+			"integrity": "sha512-lrbCJwD9saUQrqUfXvl6qoM+QN3W7tLV5pAOs+OqOmopCCz/JkE05MHedJR1xfk4IAnZuJXPVuN5+7jNA2ZCiA==",
 			"dev": true
 		},
 		"destroy": {
@@ -9332,6 +9995,12 @@
 			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
 			"dev": true
 		},
+		"event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+			"dev": true
+		},
 		"events": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -9405,6 +10074,12 @@
 				"tmp": "^0.0.33"
 			}
 		},
+		"fast-decode-uri-component": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+			"integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+			"dev": true
+		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9447,10 +10122,94 @@
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true
 		},
+		"fast-json-stringify": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.5.0.tgz",
+			"integrity": "sha512-rmw2Z8/mLkND8zI+3KTYIkNPEoF5v6GqDP/o+g7H3vjdWjBwuKpgAYFHIzL6ORRB+iqDjjtJnLIW9Mzxn5szOA==",
+			"dev": true,
+			"requires": {
+				"@fastify/deepmerge": "^1.0.0",
+				"ajv": "^8.10.0",
+				"ajv-formats": "^2.1.1",
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^2.1.0",
+				"rfdc": "^1.2.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "8.12.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+					"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"json-schema-traverse": "^1.0.0",
+						"require-from-string": "^2.0.2",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"json-schema-traverse": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+					"dev": true
+				}
+			}
+		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+			"dev": true
+		},
+		"fast-querystring": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.0.tgz",
+			"integrity": "sha512-LWkjBCZlxjnSanuPpZ6mHswjy8hQv3VcPJsQB3ltUF2zjvrycr0leP3TSTEEfvQ1WEMSRl5YNsGqaft9bjLqEw==",
+			"dev": true,
+			"requires": {
+				"fast-decode-uri-component": "^1.0.1"
+			}
+		},
+		"fast-redact": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
+			"integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==",
+			"dev": true
+		},
+		"fast-uri": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.2.0.tgz",
+			"integrity": "sha512-cIusKBIt/R/oI6z/1nyfe2FvGKVTohVRfvkOhvx0nCEW+xf5NoCXjAHcWp93uOUBchzYcsvPlrapAdX1uW+YGg==",
+			"dev": true
+		},
+		"fastify": {
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/fastify/-/fastify-4.11.0.tgz",
+			"integrity": "sha512-JteZ8pjEqd+6n+azQnQfSJV8MUMxAmxbvC2Dx/Mybj039Lf/u3kda9Kq84uy/huCpqCzZoyHIZS5JFGF3wLztw==",
+			"dev": true,
+			"requires": {
+				"@fastify/ajv-compiler": "^3.3.1",
+				"@fastify/error": "^3.0.0",
+				"@fastify/fast-json-stringify-compiler": "^4.1.0",
+				"abstract-logging": "^2.0.1",
+				"avvio": "^8.2.0",
+				"content-type": "^1.0.4",
+				"find-my-way": "^7.3.0",
+				"light-my-request": "^5.6.1",
+				"pino": "^8.5.0",
+				"process-warning": "^2.0.0",
+				"proxy-addr": "^2.0.7",
+				"rfdc": "^1.3.0",
+				"secure-json-parse": "^2.5.0",
+				"semver": "^7.3.7",
+				"tiny-lru": "^10.0.0"
+			}
+		},
+		"fastify-plugin": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.5.0.tgz",
+			"integrity": "sha512-79ak0JxddO0utAXAQ5ccKhvs6vX2MGyHHMMsmZkBANrq3hXc1CHzvNPHOcvTsVMEPl5I+NT+RO4YKMGehOfSIg==",
 			"dev": true
 		},
 		"fastq": {
@@ -9537,6 +10296,17 @@
 					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 					"dev": true
 				}
+			}
+		},
+		"find-my-way": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-7.4.0.tgz",
+			"integrity": "sha512-JFT7eURLU5FumlZ3VBGnveId82cZz7UR7OUu+THQJOwdQXxmS/g8v0KLoFhv97HreycOrmAbqjXD/4VG2j0uMQ==",
+			"dev": true,
+			"requires": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-querystring": "^1.0.0",
+				"safe-regex2": "^2.0.0"
 			}
 		},
 		"find-up": {
@@ -9834,6 +10604,18 @@
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
 			"integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
 			"dev": true
+		},
+		"h3": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/h3/-/h3-1.0.2.tgz",
+			"integrity": "sha512-25QqjQMz8pX1NI2rZ/ziNT9B8Aog7jmu2a0o8Qm9kKoH3zOhE+2icVs069h6DEp0g1Dst1+zKfRdRYcK0MogJA==",
+			"dev": true,
+			"requires": {
+				"cookie-es": "^0.5.0",
+				"destr": "^1.2.2",
+				"radix3": "^1.0.0",
+				"ufo": "^1.0.1"
+			}
 		},
 		"handlebars": {
 			"version": "4.7.7",
@@ -10300,6 +11082,17 @@
 			"requires": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
+			}
+		},
+		"light-my-request": {
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.8.0.tgz",
+			"integrity": "sha512-4BtD5C+VmyTpzlDPCZbsatZMJVgUIciSOwYhJDCbLffPZ35KoDkDj4zubLeHDEb35b4kkPeEv5imbh+RJxK/Pg==",
+			"dev": true,
+			"requires": {
+				"cookie": "^0.5.0",
+				"process-warning": "^2.0.0",
+				"set-cookie-parser": "^2.4.1"
 			}
 		},
 		"lilconfig": {
@@ -11137,6 +11930,12 @@
 			"integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
 			"dev": true
 		},
+		"on-exit-leak-free": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+			"integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w==",
+			"dev": true
+		},
 		"on-finished": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -11322,6 +12121,71 @@
 			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
 			"dev": true
 		},
+		"pino": {
+			"version": "8.8.0",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-8.8.0.tgz",
+			"integrity": "sha512-cF8iGYeu2ODg2gIwgAHcPrtR63ILJz3f7gkogaHC/TXVVXxZgInmNYiIpDYEwgEkxZti2Se6P2W2DxlBIZe6eQ==",
+			"dev": true,
+			"requires": {
+				"atomic-sleep": "^1.0.0",
+				"fast-redact": "^3.1.1",
+				"on-exit-leak-free": "^2.1.0",
+				"pino-abstract-transport": "v1.0.0",
+				"pino-std-serializers": "^6.0.0",
+				"process-warning": "^2.0.0",
+				"quick-format-unescaped": "^4.0.3",
+				"real-require": "^0.2.0",
+				"safe-stable-stringify": "^2.3.1",
+				"sonic-boom": "^3.1.0",
+				"thread-stream": "^2.0.0"
+			}
+		},
+		"pino-abstract-transport": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+			"integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+			"dev": true,
+			"requires": {
+				"readable-stream": "^4.0.0",
+				"split2": "^4.0.0"
+			},
+			"dependencies": {
+				"buffer": {
+					"version": "6.0.3",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+					"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+					"dev": true,
+					"requires": {
+						"base64-js": "^1.3.1",
+						"ieee754": "^1.2.1"
+					}
+				},
+				"readable-stream": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.3.0.tgz",
+					"integrity": "sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==",
+					"dev": true,
+					"requires": {
+						"abort-controller": "^3.0.0",
+						"buffer": "^6.0.3",
+						"events": "^3.3.0",
+						"process": "^0.11.10"
+					}
+				},
+				"split2": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+					"integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+					"dev": true
+				}
+			}
+		},
+		"pino-std-serializers": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.1.0.tgz",
+			"integrity": "sha512-KO0m2f1HkrPe9S0ldjx7za9BJjeHqBku5Ch8JyxETxT8dEFGz1PwgrHaOQupVYitpzbFSYm7nnljxD8dik2c+g==",
+			"dev": true
+		},
 		"pkg-types": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.1.tgz",
@@ -11384,10 +12248,22 @@
 				"mdast-util-from-markdown": "^1.2.0"
 			}
 		},
+		"process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+			"dev": true
+		},
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
+		},
+		"process-warning": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.1.0.tgz",
+			"integrity": "sha512-9C20RLxrZU/rFnxWncDkuF6O999NdIf3E1ws4B0ZeY3sRVPzWBMsYDE2lxjxhiXxg464cQTgKUGm8/i6y2YGXg==",
 			"dev": true
 		},
 		"proxy-addr": {
@@ -11427,10 +12303,22 @@
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
 			"dev": true
 		},
+		"quick-format-unescaped": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+			"integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+			"dev": true
+		},
 		"quick-lru": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
 			"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+			"dev": true
+		},
+		"radix3": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/radix3/-/radix3-1.0.0.tgz",
+			"integrity": "sha512-6n3AEXth91ASapMVKiEh2wrbFJmI+NBilrWE0AbiGgfm0xet0QXC8+a3K19r1UVYjUjctUgB053c3V/J6V0kCQ==",
 			"dev": true
 		},
 		"range-parser": {
@@ -11584,6 +12472,12 @@
 				"picomatch": "^2.2.1"
 			}
 		},
+		"real-require": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+			"integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+			"dev": true
+		},
 		"redent": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -11604,6 +12498,12 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true
+		},
+		"require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"dev": true
 		},
 		"resolve": {
@@ -11632,10 +12532,22 @@
 				"signal-exit": "^3.0.2"
 			}
 		},
+		"ret": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+			"integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+			"dev": true
+		},
 		"reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
 			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"dev": true
+		},
+		"rfdc": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+			"integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
 			"dev": true
 		},
 		"rimraf": {
@@ -11695,10 +12607,31 @@
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
 			"dev": true
 		},
+		"safe-regex2": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-2.0.0.tgz",
+			"integrity": "sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==",
+			"dev": true,
+			"requires": {
+				"ret": "~0.2.0"
+			}
+		},
+		"safe-stable-stringify": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.2.tgz",
+			"integrity": "sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA==",
+			"dev": true
+		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
+		},
+		"secure-json-parse": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+			"integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
 			"dev": true
 		},
 		"semver": {
@@ -11839,6 +12772,15 @@
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true
+		},
+		"sonic-boom": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.2.1.tgz",
+			"integrity": "sha512-iITeTHxy3B9FGu8aVdiDXUVAcHMF9Ss0cCsAOo2HfCrmVGT3/DT5oYaeu0M/YKZDlKTvChEyPq0zI9Hf33EX6A==",
+			"dev": true,
+			"requires": {
+				"atomic-sleep": "^1.0.0"
+			}
 		},
 		"source-map": {
 			"version": "0.6.1",
@@ -12116,6 +13058,15 @@
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
 		},
+		"thread-stream": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.3.0.tgz",
+			"integrity": "sha512-kaDqm1DET9pp3NXwR8382WHbnpXnRkN9xGN9dQt3B2+dmXiW8X1SOwmFOxAErEQ47ObhZ96J6yhZNXuyCOL7KA==",
+			"dev": true,
+			"requires": {
+				"real-require": "^0.2.0"
+			}
+		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -12130,6 +13081,12 @@
 			"requires": {
 				"readable-stream": "3"
 			}
+		},
+		"tiny-lru": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-10.0.1.tgz",
+			"integrity": "sha512-Vst+6kEsWvb17Zpz14sRJV/f8bUWKhqm6Dc+v08iShmIJ/WxqWytHzCTd6m88pS33rE2zpX34TRmOpAJPloNCA==",
+			"dev": true
 		},
 		"tinybench": {
 			"version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"@msgpack/msgpack": "^2.8.0"
 	},
 	"devDependencies": {
+		"@fastify/middie": "^8.1.0",
 		"@size-limit/preset-small-lib": "^8.1.1",
 		"@types/express": "^4.17.15",
 		"@typescript-eslint/eslint-plugin": "^5.48.2",
@@ -72,6 +73,8 @@
 		"eslint-plugin-prettier": "^4.2.1",
 		"eslint-plugin-tsdoc": "^0.2.17",
 		"express": "^4.18.2",
+		"fastify": "^4.11.0",
+		"h3": "^1.0.2",
 		"msw": "^0.49.2",
 		"node-fetch": "^3.3.0",
 		"prettier": "^2.8.3",

--- a/src/createRPCMiddleware.ts
+++ b/src/createRPCMiddleware.ts
@@ -1,11 +1,12 @@
 import { Buffer } from "node:buffer";
-import { Request, Response, NextFunction } from "express";
+import { IncomingMessage, ServerResponse } from "node:http";
 
 import { Procedures } from "./types";
 import { handleRPCRequest } from "./handleRPCRequest";
 
 export type RPCMiddleware<TProcedures extends Procedures> = {
-	(req: Request, res: Response, next: NextFunction): void;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(req: IncomingMessage, res: ServerResponse, next: (err?: Error) => any): void;
 	_procedures: TProcedures;
 };
 

--- a/src/createRPCMiddleware.ts
+++ b/src/createRPCMiddleware.ts
@@ -16,13 +16,13 @@ export type CreateRPCMiddlewareArgs<TProcedures extends Procedures> = {
 export const createRPCMiddleware = <TProcedures extends Procedures>(
 	args: CreateRPCMiddlewareArgs<TProcedures>,
 ): RPCMiddleware<TProcedures> => {
-	const fn: RPCMiddleware<TProcedures> = (req, res) => {
+	const fn: RPCMiddleware<TProcedures> = (req, res, next) => {
 		if (req.method !== "POST") {
 			res.statusCode = 405;
 
 			res.end();
 
-			return;
+			return next();
 		}
 
 		const requestBodyChunks: Buffer[] = [];
@@ -46,6 +46,8 @@ export const createRPCMiddleware = <TProcedures extends Procedures>(
 			}
 
 			res.end(Buffer.from(body), "binary");
+
+			next();
 		});
 	};
 

--- a/test/with-fastify.test.ts
+++ b/test/with-fastify.test.ts
@@ -1,0 +1,43 @@
+import { expect, it } from "vitest";
+import fastify from "fastify";
+import middie from "@fastify/middie";
+import fetch from "node-fetch";
+
+import { createRPCMiddleware } from "../src";
+import { createRPCClient } from "../src/client";
+
+type StartRPCTestServerArgs = {
+	procedures: Parameters<typeof createRPCMiddleware>[0]["procedures"];
+};
+
+const startRPCTestServer = async (args: StartRPCTestServerArgs) => {
+	const app = fastify();
+	await app.register(middie);
+
+	app.use(createRPCMiddleware({ procedures: args.procedures }));
+
+	const url = await app.listen();
+
+	return {
+		url,
+		close: () => app.close(),
+	};
+};
+
+it("works with fastify", async () => {
+	const procedures = {
+		ping: (args: { input: string }) => ({ pong: args.input }),
+	};
+	const server = await startRPCTestServer({ procedures });
+
+	const client = createRPCClient<typeof procedures>({
+		serverURL: server.url,
+		fetch,
+	});
+
+	const res = await client.ping({ input: "foo" });
+
+	server.close();
+
+	expect(res).toStrictEqual({ pong: "foo" });
+});

--- a/test/with-h3.test.ts
+++ b/test/with-h3.test.ts
@@ -1,0 +1,49 @@
+import { expect, it } from "vitest";
+import { AddressInfo } from "node:net";
+import { createServer } from "node:http";
+import { createApp, fromNodeMiddleware, toNodeListener } from "h3";
+import fetch from "node-fetch";
+
+import { createRPCMiddleware } from "../src";
+import { createRPCClient } from "../src/client";
+
+type StartRPCTestServerArgs = {
+	procedures: Parameters<typeof createRPCMiddleware>[0]["procedures"];
+};
+
+const startRPCTestServer = (args: StartRPCTestServerArgs) => {
+	const app = createApp();
+
+	app.use(
+		fromNodeMiddleware(createRPCMiddleware({ procedures: args.procedures })),
+	);
+
+	const server = createServer(toNodeListener(app));
+
+	server.listen();
+
+	const port = (server.address() as AddressInfo).port;
+
+	return {
+		url: `http://localhost:${port}`,
+		close: () => server.close(),
+	};
+};
+
+it("works with h3", async () => {
+	const procedures = {
+		ping: (args: { input: string }) => ({ pong: args.input }),
+	};
+	const server = startRPCTestServer({ procedures });
+
+	const client = createRPCClient<typeof procedures>({
+		serverURL: server.url,
+		fetch,
+	});
+
+	const res = await client.ping({ input: "foo" });
+
+	server.close();
+
+	expect(res).toStrictEqual({ pong: "foo" });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This fixes a bug where r19's Express middleware would prematurely close the response before it completed. The bug seems isolated to usage in h3 (tests in Express worked before this PR).

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
