### PR TITLE
fix: prevent bug where procedure arguments is `undefined`

### DIFF
--- a/src/handleRPCRequest.ts
+++ b/src/handleRPCRequest.ts
@@ -106,7 +106,11 @@ export const handleRPCRequest = async <TProcedures extends Procedures>(
 			},
 		);
 
-		res = await procedure(...procedureArgs);
+		// `?? []` handles an edge case where `procedureArgs` is
+		// undefined. It likely happens when the client and server has
+		// mismatching r19 versions installed (v0.1.8 introduced
+		// multiple arguments, requiring arguments to be spread).
+		res = await procedure(...(procedureArgs ?? []));
 
 		res = await replaceLeaves(res, async (value) => {
 			if (isErrorLike(value)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Prevents the following error:

```
TypeError: procedureArgs is not iterable (cannot read property undefined)
```

This error most likely happens when the r19 server uses version >= 0.1.8 and the client uses < 0.1.8. 0.8.1 introduced support for multiple arguments, prompting the change to spread the procedure arguments.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
